### PR TITLE
fix: fixed double calls to role name - Ref gestion-de-projet#2666

### DIFF
--- a/src/components/HabilitationTable/HabilitationTable.tsx
+++ b/src/components/HabilitationTable/HabilitationTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import {
+  CircularProgress,
   Grid,
   IconButton,
   Pagination,
@@ -28,10 +29,11 @@ interface HabilitationTableProps {
   total?: number
   order: Order
   setOrder?: (order: Order) => void
+  loading: boolean
 }
 
 const HabilitationTable: React.FC<HabilitationTableProps> = (props) => {
-  const { usersInHabilitation, page, setPage, onChangePage, total, order, setOrder } = props
+  const { usersInHabilitation, page, setPage, onChangePage, total, order, setOrder, loading } = props
   const { classes } = useStyles()
   const navigate = useNavigate()
 
@@ -76,6 +78,31 @@ const HabilitationTable: React.FC<HabilitationTableProps> = (props) => {
     }
   }
 
+  const renderTable = () =>
+    usersInHabilitation && usersInHabilitation.length > 0 ? (
+      usersInHabilitation.map((userAccess, index) => (
+        <TableRow key={index} className={classes.tableBodyRows}>
+          <TableCell align="left">
+            {userAccess.lastname.toLocaleUpperCase()} {userAccess.firstname}
+            <IconButton onClick={() => navigate(`/console-admin/user-profile/${userAccess.provider_username}`)} size="large">
+              <LaunchIcon fontSize="small" />
+            </IconButton>
+          </TableCell>
+          <TableCell>{userAccess.perimeter}</TableCell>
+          <TableCell>
+            {userAccess.start_datetime ? moment(userAccess.start_datetime).format('DD/MM/YYYY') : '-'}
+          </TableCell>
+          <TableCell>{userAccess.end_datetime ? moment(userAccess.end_datetime).format('DD/MM/YYYY') : '-'}</TableCell>
+        </TableRow>
+      ))
+    ) : (
+      <TableRow>
+        <TableCell colSpan={7}>
+          <Typography className={classes.loadingSpinnerContainer}>Aucun résultat à afficher</Typography>
+        </TableCell>
+      </TableRow>
+    )
+
   return (
     <Grid container justifyContent="flex-end">
       <TableContainer component={Paper}>
@@ -106,33 +133,16 @@ const HabilitationTable: React.FC<HabilitationTableProps> = (props) => {
           </TableHead>
 
           <TableBody>
-            {usersInHabilitation && usersInHabilitation.length > 0 ? (
-              usersInHabilitation.map((userAccess, index) => (
-                <TableRow key={index} className={classes.tableBodyRows}>
-                  <TableCell align="left">
-                    {userAccess.lastname.toLocaleUpperCase()} {userAccess.firstname}
-                    <IconButton
-                      onClick={() => navigate(`/console-admin/user-profile/${userAccess.provider_username}`)}
-                      size="large"
-                    >
-                      <LaunchIcon fontSize="small" />
-                    </IconButton>
-                  </TableCell>
-                  <TableCell>{userAccess.perimeter}</TableCell>
-                  <TableCell>
-                    {userAccess.start_datetime ? moment(userAccess.start_datetime).format('DD/MM/YYYY') : '-'}
-                  </TableCell>
-                  <TableCell>
-                    {userAccess.end_datetime ? moment(userAccess.end_datetime).format('DD/MM/YYYY') : '-'}
-                  </TableCell>
-                </TableRow>
-              ))
-            ) : (
+            {loading ? (
               <TableRow>
-                <TableCell colSpan={7}>
-                  <Typography className={classes.loadingSpinnerContainer}>Aucun résultat à afficher</Typography>
+                <TableCell colSpan={4}>
+                  <Grid container justifyContent={'center'}>
+                    <CircularProgress />
+                  </Grid>
                 </TableCell>
               </TableRow>
+            ) : (
+              renderTable()
             )}
           </TableBody>
         </Table>

--- a/src/views/Console-Admin/HabilitationHistory/HabilitationHistory.tsx
+++ b/src/views/Console-Admin/HabilitationHistory/HabilitationHistory.tsx
@@ -16,6 +16,7 @@ const HabilitationHistory: React.FC = () => {
   const [habilitationName, setHabilitationName] = useState<string | undefined>()
   const [usersInHabilitation, setUsersInHabilitation] = useState<UserInHabilitation[] | undefined>([])
   const [loadingPage, setLoadingPage] = useState(false)
+  const [loadingTable, setLoadingTable] = useState(false)
   const [searchInput, setSearchInput] = useState('')
   const [page, setPage] = useState(1)
   const [total, setTotal] = useState(0)
@@ -26,11 +27,11 @@ const HabilitationHistory: React.FC = () => {
 
   const { habilitationId } = useParams<{ habilitationId: string }>()
 
-  const _habilitationId = habilitationId ? habilitationId : ''
+  const _habilitationId = habilitationId ?? ''
 
   const _getHabilitationAccesses = async () => {
     try {
-      setLoadingPage(true)
+      setLoadingTable(true)
       const habilitationAccessesResp = await getUsersRole(_habilitationId, order, page, searchInput.trim())
       setUsersInHabilitation(habilitationAccessesResp?.accesses)
       setTotal(habilitationAccessesResp?.total)
@@ -39,22 +40,30 @@ const HabilitationHistory: React.FC = () => {
       setUsersInHabilitation([])
       setTotal(0)
     } finally {
-      setLoadingPage(false)
+      setLoadingTable(false)
     }
   }
 
   const getHabilitationName = async () => {
-    const habilitationResp = await getRoleUser(_habilitationId)
-    setHabilitationName(habilitationResp ?? 'Inconnu')
+    try {
+      setLoadingPage(true)
+      const habilitationResp = await getRoleUser(_habilitationId)
+      setHabilitationName(habilitationResp ?? 'Inconnu')
+    } catch (error) {
+      console.error("Erreur lors de la récupération du nom de l'habilitation", error)
+      setHabilitationName('Inconnu')
+    } finally {
+      setLoadingPage(false)
+    }
   }
+
+  useEffect(() => {
+    getHabilitationName()
+  }, [])
 
   useEffect(() => {
     setPage(1)
   }, [debouncedSearchTerm])
-
-  useEffect(() => {
-    getHabilitationName()
-  }, [habilitationName])
 
   useEffect(() => {
     _getHabilitationAccesses()
@@ -82,6 +91,7 @@ const HabilitationHistory: React.FC = () => {
                   total={total}
                   order={order}
                   setOrder={setOrder}
+                  loading={loadingTable}
                 />
               </>
             ) : (


### PR DESCRIPTION
Le bug de la pagination était dû au back, Hicham a changé ça pour que la pagination soit harmonisée partout.
De mon côté du coup j'ai juste enlevé le deuxième appel au role name qui était pas nécessaire et remis un loading exclusivement pour le tableau de la page parce que là si tu faisais une recherche y a toute la page qui passait en loading.
Voilà, la bise à qui lira :)