### PR TITLE
feat: add default placeholder message for maintenance dialog

### DIFF
--- a/src/components/Console-Admin/MaintenanceTable/MaintenanceDialog.tsx
+++ b/src/components/Console-Admin/MaintenanceTable/MaintenanceDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import {
   Button,
+  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
@@ -24,13 +25,14 @@ import type { UserRole } from 'types'
 import moment from 'moment'
 
 const DEFAULT_MAINTENANCE_MESSAGE_PLACEHOLDER = [
+  '# Nous rencontrons actuellement un incident technique',
   'Nous publierons ici chaque nouvelle information importante :',
   '',
   "• Début de l'interruption : jeudi 2 avril 2026 à 9 h 10",
   '• Prochaine mise à jour : 11 h 00',
   '',
   'En cas de besoins, contactez le support :',
-  'id.recherche.support.dsn@aphp.fr'
+  '[id.recherche.support.dsn@aphp.fr](mailto:id.recherche.support.dsn@aphp.fr)'
 ].join('\n')
 
 type MaintenanceDialogProps = {
@@ -63,6 +65,7 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
   const [endDate, setEndDate] = useState<Date | null>(
     selectedMaintenance.end_datetime ? new Date(selectedMaintenance.end_datetime) : null
   )
+  const [isDataSavedMessageHidden, setIsDataSavedMessageHidden] = useState(selectedMaintenance.is_data_saved_message_hidden)
 
   useEffect(() => {
     setMaintenanceData({ ...selectedMaintenance })
@@ -105,13 +108,22 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
     }
   }
 
+  const handleDataSavedMessageHiddenChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsDataSavedMessageHidden(e.target.checked)
+    setMaintenanceData({
+      ...maintenanceData,
+      is_data_saved_message_hidden: e.target.checked
+    })
+  }
+
   const handleSubmit = async () => {
     try {
       setLoading(true)
       const maintenanceDataToSubmit = {
         ...maintenanceData,
         start_datetime: startDate ? startDate.toISOString() : '',
-        end_datetime: endDate ? endDate.toISOString() : ''
+        end_datetime: endDate ? endDate.toISOString() : '',
+        is_data_saved_message_hidden: isDataSavedMessageHidden
       }
 
       if ('id' in maintenanceData) {
@@ -198,9 +210,9 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
               rows={4}
               error={maintenanceData.message === ''}
               helperText={
-                maintenanceData.message === ''
-                  ? "Le texte d'information aux utilisateurs est requis"
-                  : "Texte d'information aux utilisateurs"
+                (maintenanceData.message === ''
+                  ? "Le texte d'information aux utilisateurs est requis."
+                  : "Texte d'information aux utilisateurs.") + " Le format Markdown est supporté."
               }
             />
           </Grid>
@@ -254,6 +266,12 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
                 cohortes, de les éditer ou de les supprimer, seulement de consulter les données. En maintenance
                 complète, l'application est totalement inaccessible.
               </Typography>
+            </Grid>
+            <Grid item xs={12}>
+              <FormControlLabel
+                control={<Checkbox checked={maintenanceData.is_data_saved_message_hidden} onChange={handleDataSavedMessageHiddenChange} />}
+                label="Masquer le message indiquant que les données sont sauvegardées"
+              />
             </Grid>
           </Grid>
         </Grid>

--- a/src/components/Console-Admin/MaintenanceTable/MaintenanceDialog.tsx
+++ b/src/components/Console-Admin/MaintenanceTable/MaintenanceDialog.tsx
@@ -18,14 +18,20 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment'
 import 'moment/locale/fr'
 
-import {
-  MaintenancePhase,
-  MaintenancePhaseCreation,
-  createMaintenancePhase,
-  updateMaintenancePhase
-} from 'services/Console-Admin/maintenanceService'
-import { UserRole } from 'types'
+import type { MaintenancePhase, MaintenancePhaseCreation } from 'services/Console-Admin/maintenanceService'
+import { createMaintenancePhase, updateMaintenancePhase } from 'services/Console-Admin/maintenanceService'
+import type { UserRole } from 'types'
 import moment from 'moment'
+
+const DEFAULT_MAINTENANCE_MESSAGE_PLACEHOLDER = [
+  'Nous publierons ici chaque nouvelle information importante :',
+  '',
+  "• Début de l'interruption : jeudi 2 avril 2026 à 9 h 10",
+  '• Prochaine mise à jour : 11 h 00',
+  '',
+  'En cas de besoins, contactez le support :',
+  'id.recherche.support.dsn@aphp.fr'
+].join('\n')
 
 type MaintenanceDialogProps = {
   open: boolean
@@ -186,6 +192,7 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
               name="message"
               value={maintenanceData.message}
               onChange={handleMaintenanceChange}
+              placeholder={DEFAULT_MAINTENANCE_MESSAGE_PLACEHOLDER}
               variant="outlined"
               multiline
               rows={4}

--- a/src/services/Console-Admin/maintenanceService.ts
+++ b/src/services/Console-Admin/maintenanceService.ts
@@ -7,6 +7,7 @@ export type MaintenancePhaseCreation = {
   type: 'partial' | 'full'
   start_datetime: string
   end_datetime: string
+  is_data_saved_message_hidden: boolean
 }
 
 export type MaintenancePhase = MaintenancePhaseCreation & {


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #3203

## Description
Adds a placeholder message for Maintenance Phase's message field

Blocked by https://github.com/aphp/Cohort360-Back-end/pull/508
