### PR TITLE
ci: clarify publish workflow run names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,12 @@
 #
 # Contournement temporaire quality gate : workflow_dispatch possible — la branche / SHA sélectionnés
 # dans l’UI Actions sont buildés et poussés. À retirer une fois Sonar stabilisé sur ce repo.
-name: cohort360-administrationportal-publish
+name: Publish Docker administration portal
+
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('Manual publish administration portal - {0} - {1}', github.ref_name, github.sha)
+      || format('Publish Docker administration portal - {0} - {1}', github.event.workflow_run.head_branch, github.event.workflow_run.display_title) }}
 
 on:
   workflow_run:
@@ -17,6 +22,9 @@ on:
 
 jobs:
   publish:
+    name: >-
+      Build and push administration portal Docker image
+      - ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'workflow_dispatch'

--- a/src/components/Console-Admin/MaintenanceTable/MaintenanceDialog.tsx
+++ b/src/components/Console-Admin/MaintenanceTable/MaintenanceDialog.tsx
@@ -65,7 +65,9 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
   const [endDate, setEndDate] = useState<Date | null>(
     selectedMaintenance.end_datetime ? new Date(selectedMaintenance.end_datetime) : null
   )
-  const [isDataSavedMessageHidden, setIsDataSavedMessageHidden] = useState(selectedMaintenance.is_data_saved_message_hidden)
+  const [isDataSavedMessageHidden, setIsDataSavedMessageHidden] = useState(
+    selectedMaintenance.is_data_saved_message_hidden
+  )
 
   useEffect(() => {
     setMaintenanceData({ ...selectedMaintenance })
@@ -212,7 +214,7 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
               helperText={
                 (maintenanceData.message === ''
                   ? "Le texte d'information aux utilisateurs est requis."
-                  : "Texte d'information aux utilisateurs.") + " Le format Markdown est supporté."
+                  : "Texte d'information aux utilisateurs.") + ' Le format Markdown est supporté.'
               }
             />
           </Grid>
@@ -269,7 +271,12 @@ const MaintenanceDialog: React.FC<MaintenanceDialogProps> = ({
             </Grid>
             <Grid item xs={12}>
               <FormControlLabel
-                control={<Checkbox checked={maintenanceData.is_data_saved_message_hidden} onChange={handleDataSavedMessageHiddenChange} />}
+                control={
+                  <Checkbox
+                    checked={maintenanceData.is_data_saved_message_hidden}
+                    onChange={handleDataSavedMessageHiddenChange}
+                  />
+                }
                 label="Masquer le message indiquant que les données sont sauvegardées"
               />
             </Grid>


### PR DESCRIPTION
## Résumé
- Renomme le workflow de publish Docker AdministrationPortal avec un libellé humain.
- Ajoute un `run-name` basé sur la branche et le titre du run amont.
- Garde un libellé dédié pour les déclenchements manuels `workflow_dispatch`.
- Rend le nom du job Docker plus explicite dans les détails du run.
- Corrige le formatage Prettier existant dans `MaintenanceDialog.tsx` pour débloquer le check `quality` de cette PR.

## Validation
- `npx --yes yaml-lint .github/workflows/publish.yml`
- `npx --yes prettier --check src/components/Console-Admin/MaintenanceTable/MaintenanceDialog.tsx .github/workflows/publish.yml`
- `git diff --check`

Note: `actionlint` n'était pas disponible localement, et `go` non plus pour le lancer via `go run`.