### PR TITLE
feat: support right_read_logs to view logs - ref gestion-de-projet#3182

### DIFF
--- a/src/components/PortailTopBar/PortailTopBar.tsx
+++ b/src/components/PortailTopBar/PortailTopBar.tsx
@@ -63,7 +63,7 @@ const PortailTopBar: React.FC = () => {
     {
       name: 'Logs',
       pathname: '/console-admin/logs',
-      rightsToSee: userRights.right_full_admin
+      rightsToSee: userRights.right_full_admin || userRights.right_read_logs
     },
     {
       name: 'Maintenance',

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,7 @@ export type UserRole = {
   right_export_jupyter_nominative: boolean | null
   right_export_jupyter_pseudonymized: boolean | null
   right_export_csv_xlsx_nominative: boolean | null
+  right_read_logs: boolean | null
 }
 
 export type Role = {

--- a/src/utils/userRoles.ts
+++ b/src/utils/userRoles.ts
@@ -17,7 +17,8 @@ export const userDefaultRoles: UserRole = {
   right_export_csv_xlsx_nominative: false,
   right_manage_datalabs: false,
   right_read_datalabs: false,
-  right_search_patients_unlimited: false
+  right_search_patients_unlimited: false,
+  right_read_logs: false
 }
 
 export const getMyAccesses = async () => {

--- a/src/views/Console-Admin/Logs/Logs.tsx
+++ b/src/views/Console-Admin/Logs/Logs.tsx
@@ -128,7 +128,7 @@ const Logs: React.FC = () => {
               </Grid>
             ) : (
               <>
-                {userRights.right_full_admin && (
+                {(userRights.right_full_admin || userRights.right_read_logs) && (
                   <Button
                     variant="contained"
                     disableElevation


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3182

Reconnaît le nouveau droit `right_read_logs` (exposé par le back via la PR liée) pour ouvrir la consultation des logs aux utilisateurs non admins.

## Changements réalisés
- `UserRole` et `userDefaultRoles` étendus avec `right_read_logs`.
- Gate du menu "Logs" (`PortailTopBar`) étendu : `right_full_admin || right_read_logs`.
- Gate du bouton "Filtrer" sur la vue `Logs` étendu de la même manière.
- Le toggle dans la modale d'habilitation apparaît automatiquement dès que le back retourne le droit dans `/accesses/rights/` (catégorie "Logs"). Pas de modification de la modale.

## Impacts
Front uniquement. Inerte tant que la PR back (aphp/Cohort360-Back-end#524) n'est pas mergée et déployée.

## Tests réalisés
- `tsc --noEmit` et `eslint` sur les fichiers touchés : OK.

## Risques
Faibles. Si le back ne retourne pas encore le droit, `userRights.right_read_logs` reste `null` et la gate dégrade à `right_full_admin` seul, comme aujourd'hui.