### PR TITLE
fix: display Logs tile on homepage with right_read_logs

### DIFF
--- a/src/views/HomePage/HomePage.test.tsx
+++ b/src/views/HomePage/HomePage.test.tsx
@@ -39,6 +39,12 @@ describe('HomePage', () => {
     expect(screen.getByRole('button', { name: /Logs/i })).toBeInTheDocument()
   })
 
+  it('shows the Logs button when the user only has the read logs right', () => {
+    renderWithProviders(<HomePage />, { preloadedState: { me: meWith({ right_read_logs: true }) } })
+    expect(screen.getByRole('button', { name: /Logs/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Maintenance/i })).not.toBeInTheDocument()
+  })
+
   it('navigates to the chosen page when its button is clicked', async () => {
     navigate.mockClear()
     renderWithProviders(<HomePage />, { preloadedState: { me: meWith({ right_full_admin: true }) } })

--- a/src/views/HomePage/HomePage.tsx
+++ b/src/views/HomePage/HomePage.tsx
@@ -50,7 +50,7 @@ const HomePage = () => {
     {
       name: 'Logs',
       pathname: '/console-admin/logs',
-      rightsToSee: userRights.right_full_admin
+      rightsToSee: userRights.right_full_admin || userRights.right_read_logs
     },
     {
       name: 'Maintenance',


### PR DESCRIPTION
## Objectif
Suite au merge de #37, la HomePage affichait toujours la tuile **Logs** uniquement pour `right_full_admin`. Un utilisateur disposant seulement de `right_read_logs` ne voyait pas la tuile, alors qu'il pouvait accéder à la page via la barre de navigation.

## Changements réalisés
- `src/views/HomePage/HomePage.tsx` : la condition d'affichage de la tuile Logs passe de `right_full_admin` à `right_full_admin || right_read_logs`, ce qui l'aligne sur la `PortailTopBar` et la vue `Logs` qui utilisaient déjà cette condition complète.
- `src/views/HomePage/HomePage.test.tsx` : ajout d'un test de non-régression vérifiant que la tuile Logs apparaît avec `right_read_logs` seul (et que Maintenance, restée `right_full_admin`, reste masquée).

## Impacts
Front uniquement. Droits : cohérence d'affichage pour les porteurs de `right_read_logs`. Aucun changement back / API / DB.

## Tests réalisés
- Unitaires : `HomePage.test.tsx` (5 tests passants, dont le nouveau).

## Risques
Faibles. La page `/console-admin/logs` était déjà accessible à `right_read_logs` ; ce correctif ne fait qu'aligner l'affichage de la tuile sur les contrôles d'accès existants.

Fixes [gestion-de-projet#3182](https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3182)