### PR TITLE
fix(export): send patient table as 'Patient'

### DIFF
--- a/src/components/Jupyter/TransfertForm/export_tables.ts
+++ b/src/components/Jupyter/TransfertForm/export_tables.ts
@@ -10,7 +10,7 @@ export type ExportTableType = {
 
 const exportTable: ExportTableType[] = [
   {
-    id: 'patient',
+    id: 'Patient',
     name: 'Patient',
     label: 'patient',
     resourceType: ResourceType.PATIENT


### PR DESCRIPTION
## Objectif
Fixes https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3289

La table patient était envoyée sous `patient`, alors que le back attend `Patient`. La requête d'export n'atteignait donc jamais le data-exporter.

## Changements réalisés
`id` de l'entrée patient : `patient` > `Patient`.

## Impacts
Front / transfert Datalab.

## Tests réalisés
tsc + eslint.

## Risques
Aucun : l'UI s'appuie sur `label`, pas `id`.