### PR TITLE
fix(console-admin): fix pagination for role users list

### DIFF
--- a/src/services/Console-Admin/rolesService.test.ts
+++ b/src/services/Console-Admin/rolesService.test.ts
@@ -106,8 +106,10 @@ describe('getRoleUser', () => {
 describe('getUsersRole', () => {
   it('returns accesses + total on success', async () => {
     get.mockResolvedValue({ status: 200, data: { results: [{ id: 1 }], count: 1 } })
-    const res = await getUsersRole('5', { orderBy: 'username', orderDirection: 'desc' }, 1, 'foo')
-    expect(get).toHaveBeenCalledWith('/accesses/roles/5/users/?page=1&order=-username&filter_by_name=foo')
+    const res = await getUsersRole('5', { orderBy: 'username', orderDirection: 'desc' }, 2, 'foo')
+    expect(get).toHaveBeenCalledWith(
+      '/accesses/roles/5/users/?limit=20&offset=20&order=-username&filter_by_name=foo'
+    )
     expect(res).toEqual({ accesses: [{ id: 1 }], total: 1 })
   })
 

--- a/src/services/Console-Admin/rolesService.ts
+++ b/src/services/Console-Admin/rolesService.ts
@@ -72,12 +72,15 @@ export const getRoleUser = async (roleId: string): Promise<string | undefined> =
   return `${getRoleResp.data.name}`
 }
 
+const LIMIT = 20
+
 export const getUsersRole = async (role_id: string, order: Order, page?: number, searchInput?: string) => {
   const searchFilter = searchInput ? `&filter_by_name=${searchInput}` : ''
+  const offset = ((page ?? 1) - 1) * LIMIT
   const getRoleUserResp = await api.get(
-    `/accesses/roles/${role_id}/users/?page=${page}&order=${order.orderDirection === 'desc' ? '-' : ''}${
-      order.orderBy
-    }${searchFilter}`
+    `/accesses/roles/${role_id}/users/?limit=${LIMIT}&offset=${offset}&order=${
+      order.orderDirection === 'desc' ? '-' : ''
+    }${order.orderBy}${searchFilter}`
   )
   if (getRoleUserResp.status === 204) getRoleUserResp.data = []
 


### PR DESCRIPTION
## Objectif

Fix : https://gitlab.data.aphp.fr/ID/design-et-produit/ipa/cohort360/gestion-de-projet/-/work_items/3323

Corriger la pagination de la liste des utilisateurs d'une habilitation (route /console-admin/habilitations/:id/users). L'appel GET /accesses/roles/{id}/users/ renvoyait toujours les mêmes 20 premiers utilisateurs (« page 1 »), quelle que soit la page demandée.

## Changements réalisés

Le endpoint Back utilise la pagination **limit/offset** et ignore le paramètre **page** que le front envoyait.
Donc, on n'envoie plus **page** mais **limit + offset**, avec la conversion offset = (page - 1) * 20.

Test unitaire mis à jour

## Impacts
Front Portail uniquement

## Tests réalisés
Unitaires,manuel,

## Risques
Pas de points de vigilance.
